### PR TITLE
Update workflows to include label asignments

### DIFF
--- a/.github/workflows/check-gh-pages-version.yml
+++ b/.github/workflows/check-gh-pages-version.yml
@@ -1,8 +1,8 @@
 name: Check Github Pages Gem Version and Open New Issue on Change
 
-on: 
+on:
   schedule:
-    - cron: '00 12 * * *'
+    - cron: "00 12 * * *"
   workflow_dispatch:
 
 jobs:
@@ -11,21 +11,21 @@ jobs:
     steps:
       - name: Check out Daniel Ridge repo
         uses: actions/checkout@v3
-        
+
       - name: Set ENV variable for current ghpages-docker version number
         run: echo "PAGES_CURRENT_VERSION=$(cat release-versions/github-pages-gem.txt)" >> $GITHUB_ENV
-        
+
       - name: Fetch GitHub Pages Gem release version and save in ENV variable
         run: echo "PAGES_RELEASE_VERSION=$(curl -sL https://pages.github.com/versions.json | jq -r '."github-pages"')" >> $GITHUB_ENV
 
       - name: Write release version to text file
         run: |
           echo ${{ env.PAGES_RELEASE_VERSION }} > release-versions/github-pages-gem.txt
-          
+
       - name: Check for modified files
         id: git-check
         run: echo ::set-output name=modified::$([ -z "`git status --porcelain`" ] && echo "false" || echo "true")
-        
+
       - name: Commit latest GH-Pages Gem release version
         if: steps.git-check.outputs.modified == 'true'
         run: |
@@ -33,12 +33,13 @@ jobs:
           git config --global user.email 'Daniel.Ridge@hackforla.org'
           git commit -am "New release version"
           git push
-          
+
       - name: Create issue to update GH-Pages gem
         if: steps.git-check.outputs.modified == 'true'
-        run: gh issue create 
-            --repo github.com/hackforla/ops
-            --title "GHPAGES-DOCKER needs to be updated" 
-            --body "GitHub Pages is now using **v${{ env.PAGES_RELEASE_VERSION }}** of the GitHub Pages Ruby Gem. You are using **v${{ env.PAGES_CURRENT_VERSION }}**. Please refer to the [ghpages-docker Wiki](https://github.com/hackforla/ghpages-docker/wiki#how-do-you-update-ghpages-docker) for instructions on how to update."
+        run: gh issue create
+          --repo github.com/danielridgebot/check-ghpages-versions
+          --title "GHPAGES-DOCKER needs to be updated"
+          --body "GitHub Pages is now using **v${{ env.PAGES_RELEASE_VERSION }}** of the GitHub Pages Ruby Gem. You are using **v${{ env.PAGES_CURRENT_VERSION }}**. Please refer to the [ghpages-docker Wiki](https://github.com/hackforla/ghpages-docker/wiki#how-do-you-update-ghpages-docker) for instructions on how to update."
+          --label "feature':' maintenance, size':' missing, role':' Site Reliability Engineer, size':' 0.5pt, good first issue"
         env:
-            GH_TOKEN: ${{ secrets.Daniel_Ridge_PAT }}
+          GH_TOKEN: ${{ secrets.Daniel_Ridge_PAT }}

--- a/.github/workflows/check-ruby-version.yml
+++ b/.github/workflows/check-ruby-version.yml
@@ -1,9 +1,9 @@
 name: Check Ruby Version and Open New Issue on Change
 
-on: 
+on:
   workflow_run:
     workflows: ["Check Github Pages Gem Version and Open New Issue on Change"]
-    types: 
+    types:
       - completed
   workflow_dispatch:
 
@@ -16,7 +16,7 @@ jobs:
 
       - name: Set ENV variable for current Ruby version number
         run: echo "RUBY_CURRENT_VERSION=$(cat release-versions/ruby.txt)" >> $GITHUB_ENV
-        
+
       - name: Fetch Ruby release version and save in ENV variable
         run: echo "RUBY_RELEASE_VERSION=$(curl -sL https://pages.github.com/versions.json | jq -r '."ruby"')" >> $GITHUB_ENV
 
@@ -35,12 +35,13 @@ jobs:
           git config --global user.email 'Daniel.Ridge@hackforla.org'
           git commit -am "New release version"
           git push
-          
+
       - name: Create issue to update Ruby
         if: steps.git-check.outputs.modified == 'true'
-        run: gh issue create 
-            --repo github.com/hackforla/ops
-            --title "GHPAGES-DOCKER needs to be updated" 
-            --body "GitHub Pages is now using **v${{ env.RUBY_RELEASE_VERSION }}** of Ruby. You are using **v${{ env.RUBY_CURRENT_VERSION }}**. Please refer to the [ghpages-docker Wiki](https://github.com/hackforla/ghpages-docker/wiki#how-do-you-update-ghpages-docker) for instructions on how to update."
+        run: gh issue create
+          --repo github.com/danielridgebot/check-ghpages-versions
+          --title "GHPAGES-DOCKER needs to be updated"
+          --body "GitHub Pages is now using **v${{ env.RUBY_RELEASE_VERSION }}** of Ruby. You are using **v${{ env.RUBY_CURRENT_VERSION }}**. Please refer to the [ghpages-docker Wiki](https://github.com/hackforla/ghpages-docker/wiki#how-do-you-update-ghpages-docker) for instructions on how to update."
+          --label "feature&#58; maintenance, size&#58; missing, role&#58; Site Reliability Engineer, size&#58; 0.5pt"
         env:
-            GH_TOKEN: ${{ secrets.Daniel_Ridge_PAT }}
+          GH_TOKEN: ${{ secrets.Daniel_Ridge_PAT }}


### PR DESCRIPTION
Updated both files `check-gh-pages-version.yml` and `check-ruby-version.yml` so that when creating a new issue, labels `feature: maintenance`, `size: missing`, `role: Site Reliability Engineer`, `size: 0.5pt` will be added automatically. The current repo is set to danielridgebot/check-ghpages-versions for testing purpose. Once we've completed the testing, we can change it back to `github.com/hackforla/ops`. I haven't setup my access to @danielridgebot yet, so @ericvennemeyer I'll need your help to test the workflows!

Note: 
- There were some deleted spaces based on my vscode settings using `Prettier` as a default formatter, so hopefully it doesn't have any negative effects.
- It'd be helpful to confirm how to escape colons `:` in `yaml` files, so within the `--labels` flag, the same instructions were written in 2 different ways.
  - in `check-ruby-version.yml`
  ```yaml
  --label "feature&#58; maintenance, size&#58; missing, role&#58; Site Reliability Engineer, size&#58; 0.5pt"
  ```

  - in `check-gh-pages-version.yml`
  ```yaml
  --label "feature':' maintenance, size':' missing, role':' Site Reliability Engineer, size':' 0.5pt, good first issue"
  ```