### PR TITLE
Improve Daniel Ridge Bot issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,17 +1,22 @@
 ---
+name: Default
 title: Someone just opened a new issue
 assignees: danielridgebot
 labels: bug, enhancement
 ---
+
 Who's that knocking on the door, oh no! Here's who: {{ payload.sender.login }}.
 
 ### Overview
+
 REPLACE THIS TEXT -Text here that clearly states the purpose of this issue in 2 sentences or less.
 
 ### Action Items
+
 REPLACE THIS TEXT -If this is the beginning of the task this is most likely something to be researched and documented.
 
-REPLACE THIS TEXT -If the issue has already been researched, and the course of action is clear, this will describe the steps.  However, if the steps can be divided into tasks for more than one person, we recommend dividing it up into separate issues, or assigning it as a pair programming task.
+REPLACE THIS TEXT -If the issue has already been researched, and the course of action is clear, this will describe the steps. However, if the steps can be divided into tasks for more than one person, we recommend dividing it up into separate issues, or assigning it as a pair programming task.
 
 ### Resources/Instructions
+
 REPLACE THIS TEXT -If there is a website which has documentation that helps with this issue provide the link(s) here.

--- a/.github/ISSUE_TEMPLATE/update-gh-pages-version.md
+++ b/.github/ISSUE_TEMPLATE/update-gh-pages-version.md
@@ -1,0 +1,28 @@
+---
+name: "Update GitHub Pages Ruby Gem Version"
+about: "Used by bot to request updating the GitHub Pages Ruby Gem Version in ghpages Docker image."
+title: "GHPAGES-DOCKER needs to be updated - GitHub Pages Ruby Gem"
+labels: "complexity: medium,feature: docker,role: DevOps Engineer,role: Site Reliability Engineer,size: 3pt"
+projects: "CoP: DevOps: Project Board"
+milestones: "06.02 Infrastructure - Org - Should have"
+---
+
+### Overview
+
+GitHub Pages is now using **v{{ PAGES_RELEASE_VERSION }}** of the GitHub Pages Ruby Gem. You are using **v{{ PAGES_CURRENT_VERSION }}**.
+
+We need to update the GitHub Pages Ruby Gem version in the Docker image that is used to run local instances of hackforla.org, so that developers can properly test their changes.
+
+### Action Items
+
+No update to the `Dockerfile` is necessary, because the GitHub Pages gem is installed without a version number specified. This means that any time the image is rebuilt, the latest version of `github-pages` will be installed automatically. So, when `github-pages` changes, all we need to do is rebuild the image.
+
+1. [ ] Navigate to the **Actions** tab in the menu at the top of the [`ghpages-docker` repo](https://github.com/hackforla/ghpages-docker/actions).
+
+2. [ ] In the list of workflows on the left, click the [**Publish Docker Image** workflow](https://github.com/hackforla/ghpages-docker/actions/workflows/build-and-push-to-docker-hub.yml).
+
+3. [ ] Click the **Run Workflow** button on the right. This will manually trigger the GitHub action to rebuild and push the image.
+
+### Resources/Instructions
+
+- [ghpages-docker Wiki > How do you update ghpages-docker? > If the version of the `github-pages` gem has changed](https://github.com/hackforla/ghpages-docker/wiki#if-the-version-of-the-github-pages-gem-has-changed)

--- a/.github/ISSUE_TEMPLATE/update-ruby-version.md
+++ b/.github/ISSUE_TEMPLATE/update-ruby-version.md
@@ -1,0 +1,52 @@
+---
+name: "Update Ruby Version"
+about: "Used by bot to request updating the Ruby version of the Docker file in ghpages-docker repo."
+title: "GHPAGES-DOCKER needs to be updated - Ruby"
+labels: "complexity: medium,feature: docker,role: DevOps Engineer,role: Site Reliability Engineer,size: 3pt"
+projects: "CoP: DevOps: Project Board"
+milestones: "06.02 Infrastructure - Org - Should have"
+---
+
+### Overview
+
+GitHub Pages is now using **v{{ RUBY_RELEASE_VERSION }}** of Ruby. You are using **v{{ RUBY_CURRENT_VERSION }}**.
+
+We need to update the Ruby version in the Docker image that is used to run local instances of hackforla.org, so that developers can properly test their changes.
+
+### Action Items
+
+1. [ ] Search the official Ruby image repo [^1] on Docker Hub for a Ruby image tag that matches the new Ruby version number. The tags follow the format `<Ruby_Version>-<Alpine_Version>`, ex. `2.7.3-alpine3.13`. Choose the latest Alpine version unless otherwise specified.
+
+2. [ ] In the `ghpages-docker` `Dockerfile`, search for the `BUILD STAGE 1` section and replace the tag after `FROM` with the new Ruby image tag.
+
+   Ex.
+
+   ```
+   ###
+   ### BUILD STAGE 1
+   ###
+
+   ...
+
+   FROM ruby:2.7.3-alpine3.13 AS build
+   ```
+
+3. [ ] Do the same for `BUILD STAGE 2`.
+
+   Ex.
+
+   ```
+   ###
+   ### BUILD STAGE 2
+   ###
+
+   FROM ruby:2.7.3-alpine3.13
+   ```
+
+After pushing the updated `Dockerfile` to the `ghpages-docker` repo, a GitHub action will rebuild and push the updated image to Docker Hub.
+
+### Resources/Instructions
+
+- [ghpages-docker Wiki > How do you update ghpages-docker? > If the version of Ruby has changed](https://github.com/hackforla/ghpages-docker/wiki#if-the-version-of-ruby-has-changed)
+
+[^1]: [ruby on Docker Hub](https://hub.docker.com/_/ruby?tab=tags)

--- a/.github/workflows/check-gh-pages-version.yml
+++ b/.github/workflows/check-gh-pages-version.yml
@@ -39,12 +39,43 @@ jobs:
           git commit -am "New release version"
           git push
 
+      - name: Parse issue template
+        if: env.modified == 'true'
+        uses: actions/github-script@v8
+        id: parse-template
+        env:
+          PAGES_RELEASE_VERSION: ${{ env.PAGES_RELEASE_VERSION }}
+          PAGES_CURRENT_VERSION: ${{ env.PAGES_CURRENT_VERSION }}
+        with:
+          script: |
+            const PAGES_RELEASE_VERSION = process.env.PAGES_RELEASE_VERSION;
+            const PAGES_CURRENT_VERSION = process.env.PAGES_CURRENT_VERSION;
+            const script = require(
+              './github-actions/utils/parse-issue-template.js'
+            );
+            const output = await script(
+              './.github/ISSUE_TEMPLATE/update-gh-pages-version.md',
+              { PAGES_RELEASE_VERSION, PAGES_CURRENT_VERSION }
+            );
+            core.setOutput('title', output.title);
+            core.setOutput('body', output.body);
+            core.setOutput('labels', output.labels);
+            core.setOutput('milestones', output.milestones);
+            core.setOutput('projects', output.projects);
+
       - name: Create issue to update GH-Pages gem
         if: env.modified == 'true'
-        run: 'gh issue create
-          --repo github.com/hackforla/ops
-          --title "GHPAGES-DOCKER needs to be updated"
-          --body "GitHub Pages is now using **v${{ env.PAGES_RELEASE_VERSION }}** of the GitHub Pages Ruby Gem. You are using **v${{ env.PAGES_CURRENT_VERSION }}**. Please refer to the [ghpages-docker Wiki](https://github.com/hackforla/ghpages-docker/wiki#how-do-you-update-ghpages-docker) for instructions on how to update."
-          --label "feature: maintenance,feature: docker,role: Site Reliability Engineer,size: 0.5pt"'
         env:
           GH_TOKEN: ${{ secrets.DR_PAT }}
+          TITLE: ${{ steps.parse-template.outputs.title }}
+          BODY: ${{ steps.parse-template.outputs.body }}
+          LABELS: ${{ steps.parse-template.outputs.labels }}
+          MILESTONES: ${{ steps.parse-template.outputs.milestones }}
+          PROJECTS: ${{ steps.parse-template.outputs.projects }}
+        run: 'gh issue create
+          --repo "github.com/hackforla/ops"
+          --title "$TITLE"
+          --body "$BODY"
+          --label "$LABELS"
+          --milestone "$MILESTONES"
+          --project "$PROJECTS"'

--- a/.github/workflows/check-ruby-version.yml
+++ b/.github/workflows/check-ruby-version.yml
@@ -41,14 +41,43 @@ jobs:
           git commit -am "New release version"
           git push
 
+      - name: Parse issue template
+        if: env.modified == 'true'
+        uses: actions/github-script@v8
+        id: parse-template
+        env:
+          RUBY_RELEASE_VERSION: ${{ env.RUBY_RELEASE_VERSION }}
+          RUBY_CURRENT_VERSION: ${{ env.RUBY_CURRENT_VERSION }}
+        with:
+          script: |
+            const RUBY_RELEASE_VERSION = process.env.RUBY_RELEASE_VERSION;
+            const RUBY_CURRENT_VERSION = process.env.RUBY_CURRENT_VERSION;
+            const script = require(
+              './github-actions/utils/parse-issue-template.js'
+            );
+            const output = await script(
+              './.github/ISSUE_TEMPLATE/update-ruby-version.md',
+              { RUBY_RELEASE_VERSION, RUBY_CURRENT_VERSION }
+            );
+            core.setOutput('title', output.title);
+            core.setOutput('body', output.body);
+            core.setOutput('labels', output.labels);
+            core.setOutput('milestones', output.milestones);
+            core.setOutput('projects', output.projects);
+
       - name: Create issue to update Ruby
         if: env.modified == 'true'
-        run: 'gh issue create
-          --repo github.com/hackforla/ops
-          --title "GHPAGES-DOCKER needs to be updated"
-          --body "GitHub Pages is now using **v${{ env.RUBY_RELEASE_VERSION }}** of Ruby. You are using **v${{ env.RUBY_CURRENT_VERSION }}**. Please refer to the [ghpages-docker Wiki](https://github.com/hackforla/ghpages-docker/wiki#how-do-you-update-ghpages-docker) for instructions on how to update."
-          --label "feature: maintenance,feature: docker,role: Site Reliability Engineer,size: 0.5pt"'
         env:
           GH_TOKEN: ${{ secrets.DR_PAT }}
-
-
+          TITLE: ${{ steps.parse-template.outputs.title }}
+          BODY: ${{ steps.parse-template.outputs.body }}
+          LABELS: ${{ steps.parse-template.outputs.labels }}
+          MILESTONES: ${{ steps.parse-template.outputs.milestones }}
+          PROJECTS: ${{ steps.parse-template.outputs.projects }}
+        run: 'gh issue create
+          --repo "github.com/hackforla/ops"
+          --title "$TITLE"
+          --body "$BODY"
+          --label "$LABELS"
+          --milestone "$MILESTONES"
+          --project "$PROJECTS"'

--- a/github-actions/utils/parse-issue-template.js
+++ b/github-actions/utils/parse-issue-template.js
@@ -1,0 +1,84 @@
+const fs = require('fs');
+
+// ==================================================
+
+/**
+ * Parses a markdown issue template.  A frontmatter section is required and has
+ * to be between two '---' lines.  Variables within the issue template in '{{
+ * }}' curly brackets are replaced with given arguments.
+ *
+ * The returned output can then be used to create a new GitHub issue, with `gh
+ * issue create`.
+ *
+ * @param {string} filePath - Relative path to the issue template markdown file.
+ * @param {object} variables - Contains the data for replacing the variables
+ *  within the markdown file.  Keys must exactly match the names within '{{ }}'
+ *  in the template.
+ * @returns {object} Contains the frontmatter data and the body in key-value
+ *  pairs.
+ */
+async function parseIssueTemplate(filePath, variables) {
+  console.info('Parsing issue template.');
+  console.debug('filePath = ' + filePath);
+  console.debug('variables = ' + JSON.stringify(variables));
+
+  if (typeof variables !== 'object') {
+    throw Error('variables argument needs to be an Object.');
+  }
+
+  // Check file existence.
+  if (!fs.existsSync(filePath)) {
+    throw Error(`Issue template file not found: ${filePath}`);
+  }
+
+  console.info('Issue template found.');
+
+  // Read file and save lines into an Array.
+  const raw = fs.readFileSync(filePath, 'utf8');
+  const lines = raw.split(/\r?\n/);
+
+  console.info('Issue template read.');
+
+  // Extract YAML frontmatter between ---.
+  const frontmatterStart = lines.indexOf('---');
+  const frontmatterEnd = lines.indexOf('---', frontmatterStart + 1);
+  if (frontmatterStart < 0 || frontmatterEnd < 0) {
+    throw Error('Missing frontmatter section.');
+  }
+  const frontmatter = lines.slice(frontmatterStart + 1, frontmatterEnd);
+  const body = lines
+    .slice(frontmatterEnd + 1)
+    .join('\n')
+    .trim();
+
+  console.info('Frontmatter and body separated.');
+
+  const output = {};
+
+  // Extract frontmatter keys and values.
+  for (const line of frontmatter) {
+    const ind = line.indexOf(':');
+    const key = line.slice(0, ind);
+    const unformattedValue = line.slice(ind + 1).trim();
+    const value = unformattedValue.slice(1, unformattedValue.length - 1).trim();
+    output[key] = value;
+  }
+
+  console.info('Parsed frontmatter data.');
+
+  // Replace dynamic variables in body of issue template.
+  output.body = body.replaceAll(/\{\{.*?\}\}/g, (match) => {
+    const variable = match.slice(2, match.length - 2).trim();
+    return variables[variable] ?? '???';
+  });
+
+  console.info('Replaced dynamic variables in body.');
+
+  console.debug('output = ' + JSON.stringify(output));
+
+  return output;
+}
+
+// ==================================================
+
+module.exports = parseIssueTemplate;

--- a/github-actions/utils/parse-issue-template.test.js
+++ b/github-actions/utils/parse-issue-template.test.js
@@ -1,0 +1,130 @@
+'use strict';
+
+const parseIssueTemplate = require('./parse-issue-template');
+
+// ==================================================
+
+/**
+ * Ensure specific texts used in expects are up-to-date with issue template.
+ */
+describe('parseIssueTemplate', () => {
+  const updateRubyVersionFilePath =
+    './.github/ISSUE_TEMPLATE/update-ruby-version.md';
+  const RUBY_RELEASE_VERSION = '2.0';
+  const RUBY_CURRENT_VERSION = '1.0';
+
+  test('Parses issue template.', async () => {
+    // Arrange
+
+    // Act
+    const issueTemplateInfo = await parseIssueTemplate(
+      updateRubyVersionFilePath,
+      {
+        RUBY_RELEASE_VERSION,
+        RUBY_CURRENT_VERSION,
+      }
+    );
+
+    // Assert
+    expect(issueTemplateInfo.name).toBe('Update Ruby Version');
+    expect(issueTemplateInfo.about).toBe(
+      'Used by bot to request updating the Ruby version ' +
+        'of the Docker file in ghpages-docker repo.'
+    );
+    expect(issueTemplateInfo.title).toBe(
+      'GHPAGES-DOCKER needs to be updated - Ruby'
+    );
+    expect(issueTemplateInfo.labels).toBe(
+      'complexity: medium,' +
+        'feature: docker,' +
+        'role: DevOps Engineer,' +
+        'role: Site Reliability Engineer,' +
+        'size: 3pt'
+    );
+    expect(issueTemplateInfo.projects).toBe('CoP: DevOps: Project Board');
+    expect(issueTemplateInfo.milestones).toBe(
+      '06.02 Infrastructure - Org - Should have'
+    );
+    expect(issueTemplateInfo.body).toContain(
+      `GitHub Pages is now using **v${RUBY_RELEASE_VERSION}** of Ruby. ` +
+        `You are using **v${RUBY_CURRENT_VERSION}**.`
+    );
+    expect(issueTemplateInfo.body).toContain('Action Items');
+  });
+
+  test(
+    'Parses issue template without providing ' + 'dynamic variable values.',
+    async () => {
+      // Arrange
+
+      // Act
+      const issueTemplateInfo = await parseIssueTemplate(
+        updateRubyVersionFilePath,
+        {}
+      );
+
+      // Assert
+      expect(issueTemplateInfo.body).toContain(
+        'GitHub Pages is now using **v???** of Ruby. ' +
+          'You are using **v???**.'
+      );
+    }
+  );
+
+  test('Throws an error if variables argument is not given.', async () => {
+    // Arrange
+
+    // Act
+    async function runFunc() {
+      await parseIssueTemplate(updateRubyVersionFilePath);
+    }
+
+    // Assert
+    await expect(runFunc).rejects.toThrow(
+      'variables argument needs to be an Object.'
+    );
+  });
+
+  test(
+    'Throws a descriptive error message ' +
+      'if issue template file is not found.',
+    async () => {
+      // Arrange
+      const filePath = './.github/ISSUE_TEMPLATE/nonexistent.md';
+
+      // Act
+      async function runFunc() {
+        await parseIssueTemplate(filePath, {
+          RUBY_RELEASE_VERSION,
+          RUBY_CURRENT_VERSION,
+        });
+      }
+
+      // Assert
+      await expect(runFunc).rejects.toThrow(
+        `Issue template file not found: ${filePath}`
+      );
+    }
+  );
+
+  test(
+    'Throws an error if the frontmatter section ' +
+      'is missing in the issue template.',
+    async () => {
+      // Arrange
+      const filePath =
+        './github-actions/utils/test-parse-issue-template-missing-frontmatter.md';
+
+      // Act
+      async function runFunc() {
+        await parseIssueTemplate(filePath, {
+          RUBY_RELEASE_VERSION,
+          RUBY_CURRENT_VERSION,
+        });
+      }
+
+      // Assert
+      await expect(runFunc).rejects.toThrow('Missing frontmatter section.');
+    }
+  );
+});

--- a/github-actions/utils/test-parse-issue-template-missing-frontmatter.md
+++ b/github-actions/utils/test-parse-issue-template-missing-frontmatter.md
@@ -1,0 +1,1 @@
+### Overview

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('jest').Config} */
+const config = {
+  verbose: true,
+};
+
+module.exports = config;


### PR DESCRIPTION
Fixes [#52](https://github.com/hackforla/ops/issues/52)

### What changes did you make?

- Created `ISSUE_TEMPLATE` folder and moved the default issue template into it.
- Created two issue templates for instructing how to update Ruby and GitHub Pages Ruby Gem versions.
- Created a JavaScript function to parse issue templates, which will also replace the dynamic variables in the templates with version numbers.
- Created some tests for the JavaScript function, as well as a markdown file, `test-parse-issue-template-missing-frontmatter.md`, to help with one of the tests.
- Added a `jest.config.js` for running the test file when using Jest.
- Updated `check-ruby-version` and `check-github-pages-gem-version` workflows to run the JavaScript function that parses issue templates and then to pass the output data into making new GitHub issues.

### Why did you make the changes (we will use this info to test)?
- When there is a new Ruby or GitHub Pages Ruby Gem version, the Daniel Ridge bot creates GitHub issues that do not meet quality standards.
- The improved issue texts are stored in issue templates so that they do not clutter the GitHub workflow files.  It also separates issue content from workflow code.
- Issue templates are in markdown, because GitHub says that the newer issue forms, and therefore maybe the YAML version, are subject to change.  [See note at top of page here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms).
- The code to parse issue templates is placed in a JavaScript function for separation of concerns, and JavaScript is chosen because it's HackforLA's convention for GitHub Action code.
- In the workflow files, environment variables are used to pass in data in the `Parse issue template` step because [`actions/github-script` recommends it](https://github.com/actions/github-script#passing-inputs-to-the-script), and in the `Create issue to update...` step because the data contained special characters and doing it this way avoids having to escape them.

### Issues created from testing
- https://github.com/hackforla/ops/issues/159
- https://github.com/hackforla/ops/issues/160
- https://github.com/hackforla/ops/issues/158